### PR TITLE
Add native Wi-Fi and Bluetooth toggles

### DIFF
--- a/PowerControl/Helpers/RadioHelper.cs
+++ b/PowerControl/Helpers/RadioHelper.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Windows.Devices.Radios;
+
+namespace PowerControl.Helpers
+{
+    public static class RadioHelper
+    {
+        public static async Task<bool> RequestAccess()
+        {
+            return (await Radio.RequestAccessAsync()) == RadioAccessStatus.Allowed;
+        }
+
+        public static async Task SetState(Radio radio, bool enable)
+        {
+            await radio.SetStateAsync(enable ? RadioState.On : RadioState.Off);
+        }
+    }
+}

--- a/PowerControl/MenuStack.cs
+++ b/PowerControl/MenuStack.cs
@@ -18,6 +18,8 @@ namespace PowerControl
                 Options.Brightness.Instance,
                 Options.Volume.Instance,
                 Options.Microphone.Instance,
+                Options.WiFi.Instance,
+                Options.Bluetooth.Instance,
                 new Menu.MenuItemSeparator(),
                 Options.Resolution.Instance,
                 Options.RefreshRate.Instance,

--- a/PowerControl/Options/Bluetooth.cs
+++ b/PowerControl/Options/Bluetooth.cs
@@ -1,0 +1,49 @@
+using PowerControl.Helpers;
+using System;
+using System.Linq;
+using Windows.Devices.Radios;
+
+namespace PowerControl.Options
+{
+    public static class Bluetooth
+    {
+        public static Menu.MenuItemWithOptions Instance = new Menu.MenuItemWithOptions()
+        {
+            Name = "Bluetooth",
+            Options = { "Disabled", "Enabled" },
+            CurrentValue = delegate ()
+            {
+                return IsBluetoothEnabled() ? "Enabled" : "Disabled";
+            },
+            ApplyValue = (selected) =>
+            {
+                SetBluetoothEnabled(selected == "Enabled");
+                return IsBluetoothEnabled() ? "Enabled" : "Disabled";
+            }
+        };
+
+        private static bool IsBluetoothEnabled()
+        {
+            if (!RadioHelper.RequestAccess().GetAwaiter().GetResult())
+                throw new InvalidOperationException("Accès radios refusé");
+            var radios = Radio.GetRadiosAsync().GetAwaiter().GetResult();
+            var bt = radios.FirstOrDefault(r => r.Kind == RadioKind.Bluetooth);
+            return bt != null && bt.State == RadioState.On;
+        }
+
+        private static void SetBluetoothEnabled(bool enable)
+        {
+            try
+            {
+                if (!RadioHelper.RequestAccess().GetAwaiter().GetResult())
+                    throw new InvalidOperationException("Accès radios refusé");
+                var radios = Radio.GetRadiosAsync().GetAwaiter().GetResult();
+                var bt = radios.FirstOrDefault(r => r.Kind == RadioKind.Bluetooth);
+                if (bt != null)
+                    RadioHelper.SetState(bt, enable).GetAwaiter().GetResult();
+            }
+            catch { }
+        }
+    }
+}
+

--- a/PowerControl/Options/WiFi.cs
+++ b/PowerControl/Options/WiFi.cs
@@ -1,0 +1,49 @@
+using PowerControl.Helpers;
+using System;
+using System.Linq;
+using Windows.Devices.Radios;
+
+namespace PowerControl.Options
+{
+    public static class WiFi
+    {
+        public static Menu.MenuItemWithOptions Instance = new Menu.MenuItemWithOptions()
+        {
+            Name = "Wi-Fi",
+            Options = { "Disabled", "Enabled" },
+            CurrentValue = delegate ()
+            {
+                return IsWiFiEnabled() ? "Enabled" : "Disabled";
+            },
+            ApplyValue = (selected) =>
+            {
+                SetWiFiEnabled(selected == "Enabled");
+                return IsWiFiEnabled() ? "Enabled" : "Disabled";
+            }
+        };
+
+        private static bool IsWiFiEnabled()
+        {
+            if (!RadioHelper.RequestAccess().GetAwaiter().GetResult())
+                throw new InvalidOperationException("Accès radios refusé");
+            var radios = Radio.GetRadiosAsync().GetAwaiter().GetResult();
+            var wifi = radios.FirstOrDefault(r => r.Kind == RadioKind.WiFi);
+            return wifi != null && wifi.State == RadioState.On;
+        }
+
+        private static void SetWiFiEnabled(bool enable)
+        {
+            try
+            {
+                if (!RadioHelper.RequestAccess().GetAwaiter().GetResult())
+                    throw new InvalidOperationException("Accès radios refusé");
+                var radios = Radio.GetRadiosAsync().GetAwaiter().GetResult();
+                var wifi = radios.FirstOrDefault(r => r.Kind == RadioKind.WiFi);
+                if (wifi != null)
+                    RadioHelper.SetState(wifi, enable).GetAwaiter().GetResult();
+            }
+            catch { }
+        }
+    }
+}
+

--- a/PowerControl/Package.appxmanifest
+++ b/PowerControl/Package.appxmanifest
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  <Capabilities>
+    <DeviceCapability Name="radios" />
+  </Capabilities>
+</Package>

--- a/PowerControl/PowerControl.csproj
+++ b/PowerControl/PowerControl.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+    <UseWindowsSDKDesktop>true</UseWindowsSDKDesktop>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -20,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- target PowerControl to `net6.0-windows10.0.19041.0` and reference `Microsoft.Windows.SDK.Contracts`
- add `RadioHelper` and package manifest requesting radio capability
- toggle Wi-Fi and Bluetooth via `Windows.Devices.Radios`

## Testing
- `apt-get update -y` *(warns: mise.jdx.dev 403 forbidden)*
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cf9f0bfe8832892f2e6a1b804dee6