### PR TITLE
Use display settings change notifications

### DIFF
--- a/PowerControl/PowerControl.csproj
+++ b/PowerControl/PowerControl.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
+    <PackageReference Include="System.Management" Version="7.0.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary
- replace polling display timer with `SystemEvents.DisplaySettingsChanged`
- trigger `ProfilesController` updates directly from display change events
- listen for `Win32_DeviceChangeEvent` via WMI to handle HDMI connect/disconnect

## Testing
- `dotnet build SteamDeckTools.sln -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f41008eb88328bd56809348c93dc9